### PR TITLE
Prevent reinforcement assault frigates on mission 9

### DIFF
--- a/2.3/leveldata/campaign/homeworldclassic/mission09/referencefleet.lua
+++ b/2.3/leveldata/campaign/homeworldclassic/mission09/referencefleet.lua
@@ -9,48 +9,48 @@ Fleet =
     },
     {
         Type = "Kus_ResearchShip",
-        Number = 1,
+        Number = 3,
     },
     {
         Type = "Kus_ResourceCollector",
-        Number = 4,
+        Number = 8,
     },
     {
         Type = "Kus_SalvageCorvette",
-        Number = 4,
+        Number = 14,
     }, 
     {
         Type = "Kus_Interceptor",
-        Number =12,
+        Number =50,
     },
     {
         Type = "Kus_LightCorvette",
-        Number = 5,
+        Number = 25,
     },
     {
         Type = "Kus_HeavyCorvette",
-        Number = 9,
+        Number = 15,
     },
     {
         Type = "Kus_AttackBomber",
-        Number = 14,
+        Number = 40,
     },
     {
         Type = "Kus_AssaultFrigate",
-        Number = 5,
+        Number = 11,
     },
     {
         Type = "Kus_IonCannonFrigate",
-        Number = 4,
+        Number = 10,
     },
     {
         Type = "Kus_Destroyer",
-        Number = 2,
+        Number = 8,
     },
 }
 
 -- and we think they should have this much money:
-RUs = 2000
+RUs = 50000
 
 --Load expanded options
 dofilepath("data:scripts/playerspatch_util.lua")


### PR DESCRIPTION
Reinforcement counts on this mission seem highly sensitive and slightly reducing reference fleet expectations from these numbers resulted in total assault frigates going from 1 to 19. Could look into making the reinforcement count less sensitive in the future, for now it's easiest just to block reinforcements entirely.