### PR TITLE
Entity persistence

### DIFF
--- a/2.3/scripts/playerspatch_ships_persistence.lua
+++ b/2.3/scripts/playerspatch_ships_persistence.lua
@@ -1,0 +1,112 @@
+-- Group management --
+-- Use this object to persist memory across script calls.
+--
+-- This is just a global table of tables with a small api.
+-- MemGroups represents an associative array of ship groups.
+-- The groups themselves also come with a default set of accessors,
+-- which can be extended via custom_attribs when creating the group.
+--
+-- Accessing the groups themselves is not recommended, but obviously
+-- entirely possible.
+
+MemGroup = {
+	_groups = {},
+	-- _new
+	-- 1: group_name: string
+	-- 2: custom_attribs: table<any, any>
+	--
+	-- return: MemGroup
+	--
+	-- Internal function. Creates a new MemGroup on the _groups
+	-- table. MemGroups are tables of Entities. Entities are tables
+	-- with the following attributes:
+	-- [entity]:
+	--   _tick: string
+	--   GetTick: function() => number
+	--   NextTick: function() => number
+	-- In addition, the entity will also host the attributes defined
+	-- in custom_attributes.
+	_new = function(group_name, custom_attribs)
+		return {
+			_entities = {},
+			_custom_attribs = custom_attribs,
+			get = function (entityID)
+				return MemGroup._groups[group_name]._entities[entityID]
+			end,
+			set = function (this, entityID, entity)
+				MemGroup._groups[group_name].entites[entityID] = entity
+				local e = MemGroup._groups[group_name].entites[entityID]
+				if (e._tick == nil) then
+					e._tick = 0
+				end
+				function e:NextTick()
+					self._tick = self._tick + 1
+					if (self._tick > 128) then
+						self._tick = 0
+					end
+					return self._tick
+				end
+				function e:GetTick()
+					return self._tick
+				end
+				for i, v in MemGroup._groups[group_name]._custom_attribs do
+					e[i] = v
+				end
+				return e
+			end,
+			delete = function(entityID)
+				MemGroup._groups[group_name]._entites[entityID] = nil
+			end
+		}
+	end,
+	-- Create
+	-- 1: group_name: string
+	-- 2: custom_attribs: table<any: any>
+	--
+	-- return: MemGroup
+	--
+	-- 'Soft' creation of group. If the group already exists, the already
+	-- present group is returned instead.
+	Create = function (group_name, custom_attribs)
+		if (MemGroup._groups[group_name] == nil) then
+			return MemGroup.ForceCreate(group_name, custom_attribs)
+		end
+		return MemGroup._groups[group_name]
+	end,
+
+	-- ForceCreate
+	-- 1: group_name: string
+	-- 2: custom_attribs: table<any: any>
+	--
+	-- return: MemGroup
+	--
+	-- 'Hard' creation of group. If a group with this name already exists,
+	-- it will be silently overwritten. Internally calls NewMemGroup.
+	ForceCreate = function (group_name, custom_attribs)
+		if custom_attribs == nil then
+			custom_attribs = {}
+		end
+		MemGroup._groups[group_name] = MemGroup._new(group_name, custom_attribs)
+		return MemGroup._groups[group_name]
+	end,
+
+	-- Get
+	-- 1: group_name: string
+	--
+	-- return: MemGroup
+	--
+	-- Returns the group indexed by group_name.
+	Get = function (group_name)
+		return MemGroup._groups[group_name]
+	end,
+
+	-- Exists
+	-- 1: group_name
+	--
+	-- return: boolean
+	--
+	-- Checks the existence of the group indexed by group_name
+	Exists = function (group_name)
+		return MemGroup._groups[group_name] ~= nil
+	end
+}

--- a/2.3/scripts/playerspatch_ships_persistence.lua
+++ b/2.3/scripts/playerspatch_ships_persistence.lua
@@ -27,13 +27,11 @@ MemGroup = {
 	-- In addition, the entity will also host the attributes defined
 	-- in custom_attributes.
 	_new = function(group_name, custom_attribs)
-		return {
+		local new_group = {
 			_entities = {},
+			_group_name = group_name,
 			_custom_attribs = custom_attribs,
-			get = function (entityID)
-				return MemGroup._groups[group_name]._entities[entityID]
-			end,
-			set = function (this, entityID, entity)
+			set = function (entityID, entity)
 				MemGroup._groups[group_name].entites[entityID] = entity
 				local e = MemGroup._groups[group_name].entites[entityID]
 				if (e._tick == nil) then
@@ -58,6 +56,9 @@ MemGroup = {
 				MemGroup._groups[group_name]._entites[entityID] = nil
 			end
 		}
+		function new_group:get(entityID)
+			return self._entites[entityID]
+		end
 	end,
 	-- Create
 	-- 1: group_name: string

--- a/2.3/scripts/playerspatch_ships_persistence.lua
+++ b/2.3/scripts/playerspatch_ships_persistence.lua
@@ -24,41 +24,45 @@ MemGroup = {
 	--   _tick: string
 	--   GetTick: function() => number
 	--   NextTick: function() => number
-	-- In addition, the entity will also host the attributes defined
+	-- In addition, the entities will also host the attributes defined
 	-- in custom_attributes.
 	_new = function(group_name, custom_attribs)
 		local new_group = {
 			_entities = {},
 			_group_name = group_name,
 			_custom_attribs = custom_attribs,
-			set = function (entityID, entity)
-				MemGroup._groups[group_name].entites[entityID] = entity
-				local e = MemGroup._groups[group_name].entites[entityID]
-				if (e._tick == nil) then
-					e._tick = 0
-				end
-				function e:NextTick()
-					self._tick = self._tick + 1
-					if (self._tick > 128) then
-						self._tick = 0
-					end
-					return self._tick
-				end
-				function e:GetTick()
-					return self._tick
-				end
-				for i, v in MemGroup._groups[group_name]._custom_attribs do
-					e[i] = v
-				end
-				return e
-			end,
-			delete = function(entityID)
-				MemGroup._groups[group_name]._entites[entityID] = nil
-			end
 		}
 		function new_group:get(entityID)
-			return self._entites[entityID]
+			return self._entities[entityID]
 		end
+		function new_group:set(entityID, entity)
+			if (entity == nil) then
+				entity = {}
+			end
+			self._entities[entityID] = entity
+			local e = self._entities[entityID]
+			if (e._tick == nil) then
+				e._tick = 0
+			end
+			function e:NextTick()
+				self._tick = self._tick + 1
+				if (self._tick >= 127) then
+					self._tick = 0
+				end
+				return self._tick
+			end
+			function e:GetTick()
+				return self._tick
+			end
+			for i, v in self._custom_attribs do
+				e[i] = v
+			end
+			return e
+		end
+		function new_group:delete(entityID)
+			self._entities[entityID] = nil
+		end
+		return new_group
 	end,
 	-- Create
 	-- 1: group_name: string


### PR DESCRIPTION
Just a more rigorous take on the kind've thing I was doing with cloaked fighters.
This is a small module which allows for persisting entities such as ships and keeping track of them beyond script calls.

Out of the box, the only thing that is tracked is a number referred to as `._tick`, which is accessed via `GetTick` and `NextTick`, which return it's value and increment it respectively. `._tick` is bounded for the values of `0...127`.

You can store whatever else you'd like to on the entity though.