### PR TITLE
Sf code refactor

### DIFF
--- a/2.3/scripts/playerspatch-lib/hw1_support_frigate.lua
+++ b/2.3/scripts/playerspatch-lib/hw1_support_frigate.lua
@@ -1,0 +1,64 @@
+function SupportFrigate_Docked_HS_Init(shipID)
+	SobGroup_Create("LatchDockTempGroup"..shipID)
+	SobGroup_CreateIfNotExist("LatchDockTempGroup")
+end
+
+function SupportFrigate_Docked_HS_Update(CustomGroup, shipID)
+	if (SobGroup_AreAllInRealSpace(CustomGroup)==1) then
+		if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then --Exited Hyperspace with ships docked
+			if (SobGroup_IsDoingAbility("LatchDockTempGroup"..shipID, AB_Dock)==0) then
+				SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
+				SobGroup_DockSobGroupAndStayDocked("LatchDockTempGroup"..shipID, CustomGroup)
+			end
+			SobGroup_Clear("LatchDockTempGroup")
+			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
+			if (SobGroup_Count("LatchDockTempGroup")>=SobGroup_Count("LatchDockTempGroup"..shipID)) then --All ships docked
+				if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then
+					SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,1)
+					SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 0)
+					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
+					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 1)
+					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 1)
+					SobGroup_Clear("LatchDockTempGroup"..shipID)
+				end
+			end
+		elseif(SobGroup_GetROE(CustomGroup)==0)then --In Offensive ROE, launch all ships
+			SobGroup_Clear("LatchDockTempGroup")
+			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
+			SobGroup_Launch("LatchDockTempGroup", CustomGroup)
+		elseif(SobGroup_GetROE(CustomGroup)==2)then --In Passive ROE, all ships stay docked
+			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
+			SobGroup_ForceStayDockedIfDocking("LatchDockTempGroup")
+			SobGroup_Clear("LatchDockTempGroup")
+		end
+	elseif (SobGroup_Empty("LatchDockTempGroup"..shipID)==1) then --Hyperspacing, get all ships docked with
+		SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup"..shipID)
+		SobGroup_AbilityActivate(CustomGroup, AB_Lights, 0)
+		SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,0)
+		SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 1)
+		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 0)
+		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 0)
+		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 0)
+	else --Hyperspacing with ships docked
+		if (SobGroup_AreAllInHyperspace("LatchDockTempGroup"..shipID)==0)and(SobGroup_CanDoAbility(CustomGroup,AB_Lights)==0) then --Entering Hyperspace
+			SobGroup_Despawn("LatchDockTempGroup"..shipID)
+		elseif (SobGroup_AreAllInHyperspace("LatchDockTempGroup"..shipID)==1)and(SobGroup_AreAllInHyperspace(CustomGroup)==1) then --All In Hyperspace
+			SobGroup_AbilityActivate(CustomGroup, AB_Lights, 1)
+		elseif (SobGroup_AreAllInHyperspace(CustomGroup)==0)and(SobGroup_CanDoAbility(CustomGroup,AB_Lights)==1) then --Exiting Hyperspace
+			Volume_AddSphere("LatchDockTempVolume", SobGroup_GetPosition(CustomGroup), 0)
+			SobGroup_Spawn("LatchDockTempGroup"..shipID, "LatchDockTempVolume")
+			Volume_Delete("LatchDockTempVolume")
+		end
+	end
+end
+
+function SupportFrigate_Docked_HS_Destroy(shipID)
+	if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then
+		SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,1)
+		SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 0)
+		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
+		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 1)
+		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 1)
+		SobGroup_Clear("LatchDockTempGroup"..shipID)
+	end
+end

--- a/2.3/scripts/playerspatch_ships_util.lua
+++ b/2.3/scripts/playerspatch_ships_util.lua
@@ -1,4 +1,5 @@
 -- Ships utility functions
+doscanpath("data:scripts/playerspatch-lib", "*.lua")
 
 -- Show hw1 production subsystems
 function ShowProductionSubsystems(CustomGroup, playerIndex, shipType)

--- a/2.3/ship/kus_supportfrigate/kus_supportfrigate.lua
+++ b/2.3/ship/kus_supportfrigate/kus_supportfrigate.lua
@@ -1,66 +1,12 @@
 function Create_Kus_SupportFrigate(CustomGroup, playerIndex, shipID)
-	SobGroup_Create("LatchDockTempGroup"..shipID)
-	SobGroup_CreateIfNotExist("LatchDockTempGroup")
+	SupportFrigate_Docked_HS_Init(shipID)
 end
 
 function Update_Kus_SupportFrigate(CustomGroup, playerIndex, shipID)
 	NoSalvageScuttle(CustomGroup, playerIndex, shipID)
-
-	if (SobGroup_AreAllInRealSpace(CustomGroup)==1) then
-		if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then --Exited Hyperspace with ships docked
-			if (SobGroup_IsDoingAbility("LatchDockTempGroup"..shipID, AB_Dock)==0) then
-				SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
-				SobGroup_DockSobGroupAndStayDocked("LatchDockTempGroup"..shipID, CustomGroup)
-			end
-			SobGroup_Clear("LatchDockTempGroup")
-			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
-			if (SobGroup_Count("LatchDockTempGroup")>=SobGroup_Count("LatchDockTempGroup"..shipID)) then --All ships docked
-				if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then
-					SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,1)
-					SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 0)
-					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
-					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 1)
-					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 1)
-					SobGroup_Clear("LatchDockTempGroup"..shipID)
-				end
-			end
-		elseif(SobGroup_GetROE(CustomGroup)==0)then --In Offensive ROE, launch all ships
-			SobGroup_Clear("LatchDockTempGroup")
-			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
-			SobGroup_Launch("LatchDockTempGroup", CustomGroup)
-		elseif(SobGroup_GetROE(CustomGroup)==2)then --In Passive ROE, all ships stay docked
-			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
-			SobGroup_ForceStayDockedIfDocking("LatchDockTempGroup")
-			SobGroup_Clear("LatchDockTempGroup")
-		end
-	elseif (SobGroup_Empty("LatchDockTempGroup"..shipID)==1) then --Hyperspacing, get all ships docked with
-		SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup"..shipID)
-		SobGroup_AbilityActivate(CustomGroup, AB_Lights, 0)
-		SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,0)
-		SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 1)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 0)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 0)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 0)
-	else --Hyperspacing with ships docked
-		if (SobGroup_AreAllInHyperspace("LatchDockTempGroup"..shipID)==0)and(SobGroup_CanDoAbility(CustomGroup,AB_Lights)==0) then --Entering Hyperspace
-			SobGroup_Despawn("LatchDockTempGroup"..shipID)
-		elseif (SobGroup_AreAllInHyperspace("LatchDockTempGroup"..shipID)==1)and(SobGroup_AreAllInHyperspace(CustomGroup)==1) then --All In Hyperspace
-			SobGroup_AbilityActivate(CustomGroup, AB_Lights, 1)
-		elseif (SobGroup_AreAllInHyperspace(CustomGroup)==0)and(SobGroup_CanDoAbility(CustomGroup,AB_Lights)==1) then --Exiting Hyperspace
-			Volume_AddSphere("LatchDockTempVolume", SobGroup_GetPosition(CustomGroup), 0)
-			SobGroup_Spawn("LatchDockTempGroup"..shipID, "LatchDockTempVolume")
-			Volume_Delete("LatchDockTempVolume")
-		end
-	end
+	SupportFrigate_Docked_HS_Update(CustomGroup, shipID)
 end
 
 function Destroy_Kus_SupportFrigate(CustomGroup, playerIndex, shipID)
-	if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then
-		SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,1)
-		SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 0)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 1)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 1)
-		SobGroup_Clear("LatchDockTempGroup"..shipID)
-	end
+	SupportFrigate_Docked_HS_Destroy(shipID)
 end

--- a/2.3/ship/tai_supportfrigate/tai_supportfrigate.lua
+++ b/2.3/ship/tai_supportfrigate/tai_supportfrigate.lua
@@ -1,66 +1,12 @@
 function Create_Tai_SupportFrigate(CustomGroup, playerIndex, shipID)
-	SobGroup_Create("LatchDockTempGroup"..shipID)
-	SobGroup_CreateIfNotExist("LatchDockTempGroup")
+	SupportFrigate_Docked_HS_Init(shipID)
 end
 
 function Update_Tai_SupportFrigate(CustomGroup, playerIndex, shipID)
 	NoSalvageScuttle(CustomGroup, playerIndex, shipID)
-
-	if (SobGroup_AreAllInRealSpace(CustomGroup)==1) then
-		if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then --Exited Hyperspace with ships docked
-			if (SobGroup_IsDoingAbility("LatchDockTempGroup"..shipID, AB_Dock)==0) then
-				SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
-				SobGroup_DockSobGroupAndStayDocked("LatchDockTempGroup"..shipID, CustomGroup)
-			end
-			SobGroup_Clear("LatchDockTempGroup")
-			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
-			if (SobGroup_Count("LatchDockTempGroup")>=SobGroup_Count("LatchDockTempGroup"..shipID)) then --All ships docked
-				if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then
-					SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,1)
-					SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 0)
-					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
-					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 1)
-					SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 1)
-					SobGroup_Clear("LatchDockTempGroup"..shipID)
-				end
-			end
-		elseif(SobGroup_GetROE(CustomGroup)==0)then --In Offensive ROE, launch all ships
-			SobGroup_Clear("LatchDockTempGroup")
-			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
-			SobGroup_Launch("LatchDockTempGroup", CustomGroup)
-		elseif(SobGroup_GetROE(CustomGroup)==2)then --In Passive ROE, all ships stay docked
-			SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup")
-			SobGroup_ForceStayDockedIfDocking("LatchDockTempGroup")
-			SobGroup_Clear("LatchDockTempGroup")
-		end
-	elseif (SobGroup_Empty("LatchDockTempGroup"..shipID)==1) then --Hyperspacing, get all ships docked with
-		SobGroup_GetSobGroupDockedWithGroup(CustomGroup, "LatchDockTempGroup"..shipID)
-		SobGroup_AbilityActivate(CustomGroup, AB_Lights, 0)
-		SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,0)
-		SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 1)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 0)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 0)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 0)
-	else --Hyperspacing with ships docked
-		if (SobGroup_AreAllInHyperspace("LatchDockTempGroup"..shipID)==0)and(SobGroup_CanDoAbility(CustomGroup,AB_Lights)==0) then --Entering Hyperspace
-			SobGroup_Despawn("LatchDockTempGroup"..shipID)
-		elseif (SobGroup_AreAllInHyperspace("LatchDockTempGroup"..shipID)==1)and(SobGroup_AreAllInHyperspace(CustomGroup)==1) then --All In Hyperspace
-			SobGroup_AbilityActivate(CustomGroup, AB_Lights, 1)
-		elseif (SobGroup_AreAllInHyperspace(CustomGroup)==0)and(SobGroup_CanDoAbility(CustomGroup,AB_Lights)==1) then --Exiting Hyperspace
-			Volume_AddSphere("LatchDockTempVolume", SobGroup_GetPosition(CustomGroup), 0)
-			SobGroup_Spawn("LatchDockTempGroup"..shipID, "LatchDockTempVolume")
-			Volume_Delete("LatchDockTempVolume")
-		end
-	end
+	SupportFrigate_Docked_HS_Update(CustomGroup, shipID)
 end
 
 function Destroy_Tai_SupportFrigate(CustomGroup, playerIndex, shipID)
-	if (SobGroup_Empty("LatchDockTempGroup"..shipID)==0) then
-		SobGroup_MakeSelectable("LatchDockTempGroup"..shipID,1)
-		SobGroup_SetHidden( "LatchDockTempGroup"..shipID, 0)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Dock, 1)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Scuttle, 1)
-		SobGroup_AbilityActivate("LatchDockTempGroup"..shipID, AB_Attack, 1)
-		SobGroup_Clear("LatchDockTempGroup"..shipID)
-	end
+	SupportFrigate_Docked_HS_Destroy(shipID)
 end


### PR DESCRIPTION
Moved repeated bulky code into its own lib file

Going forwards, I want to keep ship files as clean as possible, and move implementation away either to the main util file (for actual utility), or to lib files (for ship-specific stuff or naturally modular stuff).