### PR TITLE
Assault frigate projectiles

### DIFF
--- a/2.3/weapon/kus_assaultbomb/kus_assaultbomb.wepn
+++ b/2.3/weapon/kus_assaultbomb/kus_assaultbomb.wepn
@@ -1,9 +1,9 @@
 StartWeaponConfig(NewWeaponType,"Gimble","Bullet","Dread_Bomb","Normal",1750,3200,0,0,0,0,1,1,1,6.0,0,0,0,0,0,0,0.1,"Normal",0,0,0);
-AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",200,275,"");
+AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",220,255,"");
 setPenetration(NewWeaponType,5,1,
-{Unarmoured=0.13},
-{Unarmoured_hw1=0.13},
-{LightArmour=0.5},
+{Unarmoured=1},
+{Unarmoured_hw1=1},
+{LightArmour=0.7},
 {LightArmour_hw1=0.9},
 {ResArmour=0.2},
 {PlanetKillerArmour=0},
@@ -23,8 +23,8 @@ setAccuracy(NewWeaponType,1,
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},
-{Fighter=0.03},
-{Fighter_hw1=0.03},
+{Fighter=0.1},
+{Fighter_hw1=0.1},
 {Corvette=0.7},
 {Corvette_hw1=0.7},
 {munition=0.05},
@@ -32,7 +32,7 @@ setAccuracy(NewWeaponType,1,
 {SmallCapitalShip=0.93},
 {BigCapitalShip=0.93},
 {SubSystem=1},
-{ResourceLarge=0.6});
+{ResourceLarge=0.93});
 setAngles(NewWeaponType,40,0,0,0,0);
 setMissProperties(NewWeaponType, 0.02, 0.03, 0.60, 0.70, 0.65, 0.65);
 setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 2.0, 200, 1.1, 300, 0.60, 400, 0.30);

--- a/2.3/weapon/kus_assaultgun/kus_assaultgun.wepn
+++ b/2.3/weapon/kus_assaultgun/kus_assaultgun.wepn
@@ -1,10 +1,10 @@
-StartWeaponConfig(NewWeaponType,"AnimatedTurret","Bullet","HW1Kinetic_Small","Normal",1500,3200,0,0,0,0,1,1,1,2.9,0,0,1,0,40,40,0.1,"Normal",1,0,0);
+StartWeaponConfig(NewWeaponType,"AnimatedTurret","Bullet","HW1Kinetic_Small","Normal",2200,3200,0,0,0,0,1,1,1,2.9,0,0,1,0,60,60,0.1,"Normal",1,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",100,100,"");
 setPenetration(NewWeaponType,5,1,
-{Unarmoured=0.10},
-{Unarmoured_hw1=0.10},
-{LightArmour=0.16},
-{LightArmour_hw1=0.16},
+{Unarmoured=0.35},
+{Unarmoured_hw1=0.35},
+{LightArmour=0.2},
+{LightArmour_hw1=0.3},
 {PlanetKillerArmour=0},
 {SwarmerArmor=0.45},
 {SpaceMineArmor=1},
@@ -28,16 +28,15 @@ setAccuracy(NewWeaponType,1,
 {Corvette=0.90},
 {Corvette_hw1=0.90},
 {munition=0.04},
-{Frigate=0.90},
+{Frigate=0.95},
 {SmallCapitalShip=0.89},
 {BigCapitalShip=0.89},
 {SubSystem=1},
-{Resource=0.89},
-{ResourceLarge=0.6});
+{ResourceLarge=0.95});
 setAngles(NewWeaponType,10,-150,150,-10,60);
 addAnimTurretSound(NewWeaponType,"Data:Sound/SFX/ETG/SPECIAL/SPECIAL_ABILITIES_TURRET_ON");
 setMissProperties(NewWeaponType, 0.02, 0.04, 0.50, 0.60, 0.70, 0.70);
 setLifetimeMult(NewWeaponType, 1.75);
-setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0);
+setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0, 350, 0.6);
 setBallistics(NewWeaponType,0,0.0);
 setFireMultFactor(NewWeaponType, 1.0);

--- a/2.3/weapon/tai_assaultbomb/tai_assaultbomb.wepn
+++ b/2.3/weapon/tai_assaultbomb/tai_assaultbomb.wepn
@@ -1,10 +1,10 @@
 StartWeaponConfig(NewWeaponType,"Gimble","Bullet","Dread_Bomb","Normal",1750,3200,0,0,0,0,1,1,1,6.0,0,0,0,0,0,0,0.1,"Normal",0,0,0);
-AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",200,275,"");
+AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",220,255,"");
 setPenetration(NewWeaponType,5,1,
-{Unarmoured=0.13},
-{Unarmoured_hw1=0.13},
-{LightArmour=0.5},
-{LightArmour_hw1=0.9},
+{Unarmoured=1},
+{Unarmoured_hw1=1},
+{LightArmour=0.8},
+{LightArmour_hw1=0.8},
 {ResArmour=0.2},
 {PlanetKillerArmour=0},
 {SwarmerArmor=0.13},
@@ -23,8 +23,8 @@ setAccuracy(NewWeaponType,1,
 {Torpedo=0},
 {HeavyMissile=0},
 {SmallMissile=0},
-{Fighter=0.03},
-{Fighter_hw1=0.03},
+{Fighter=0.1},
+{Fighter_hw1=0.1},
 {Corvette=0.7},
 {Corvette_hw1=0.7},
 {munition=0.05},
@@ -32,7 +32,7 @@ setAccuracy(NewWeaponType,1,
 {SmallCapitalShip=0.93},
 {BigCapitalShip=0.93},
 {SubSystem=1},
-{ResourceLarge=0.6});
+{ResourceLarge=0.93});
 setAngles(NewWeaponType,40,0,0,0,0);
 setMissProperties(NewWeaponType, 0.02, 0.03, 0.60, 0.70, 0.65, 0.65);
 setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 2.0, 200, 1.1, 300, 0.60, 400, 0.30);

--- a/2.3/weapon/tai_assaultgun1/tai_assaultgun1.wepn
+++ b/2.3/weapon/tai_assaultgun1/tai_assaultgun1.wepn
@@ -1,10 +1,10 @@
-StartWeaponConfig(NewWeaponType,"AnimatedTurret","Bullet","HW1Kinetic_Small","Normal",1500,3200,0,0,0,0,1,1,1,2.9,0,0,1,0,40,40,0.1,"Normal",1,0,0);
+StartWeaponConfig(NewWeaponType,"AnimatedTurret","Bullet","HW1Kinetic_Small","Normal",2200,3200,0,0,0,0,1,1,1,2.9,0,0,1,0,40,40,0.1,"Normal",1,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",100,100,"");
 setPenetration(NewWeaponType,5,1,
-{Unarmoured=0.10},
-{Unarmoured_hw1=0.10},
-{LightArmour=0.16},
-{LightArmour_hw1=0.16},
+{Unarmoured=0.35},
+{Unarmoured_hw1=0.35},
+{LightArmour=0.2},
+{LightArmour_hw1=0.2},
 {PlanetKillerArmour=0},
 {SwarmerArmor=0.45},
 {SpaceMineArmor=1},
@@ -28,17 +28,16 @@ setAccuracy(NewWeaponType,1,
 {Corvette=0.90},
 {Corvette_hw1=0.90},
 {munition=0.04},
-{Frigate=0.90},
+{Frigate=0.95},
 {SmallCapitalShip=0.89},
 {BigCapitalShip=0.89},
 {SubSystem=1},
-{Resource=0.89},
-{ResourceLarge=0.6});
+{ResourceLarge=0.95});
 setAngles(NewWeaponType,10,-20,160,-10,60);
 setMiscValues(NewWeaponType,0.25,0);
 addAnimTurretSound(NewWeaponType,"Data:Sound/SFX/ETG/SPECIAL/SPECIAL_ABILITIES_TURRET_ON");
 setMissProperties(NewWeaponType, 0.02, 0.04, 0.50, 0.60, 0.70, 0.70);
 setLifetimeMult(NewWeaponType, 1.75);
-setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0);
+setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0, 350, 0.6);
 setBallistics(NewWeaponType,0,0.0);
 setFireMultFactor(NewWeaponType, 1.0);

--- a/2.3/weapon/tai_assaultgun2/tai_assaultgun2.wepn
+++ b/2.3/weapon/tai_assaultgun2/tai_assaultgun2.wepn
@@ -1,10 +1,10 @@
 StartWeaponConfig(NewWeaponType,"AnimatedTurret","Bullet","HW1Kinetic_Small","Normal",1500,3200,0,0,0,0,1,1,1,2.9,0,0,1,0,40,40,0.1,"Normal",1,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",100,100,"");
 setPenetration(NewWeaponType,5,1,
-{Unarmoured=0.10},
-{Unarmoured_hw1=0.10},
-{LightArmour=0.16},
-{LightArmour_hw1=0.16},
+{Unarmoured=0.35},
+{Unarmoured_hw1=0.35},
+{LightArmour=0.2},
+{LightArmour_hw1=0.2},
 {PlanetKillerArmour=0},
 {SwarmerArmor=0.45},
 {SpaceMineArmor=1},
@@ -28,17 +28,16 @@ setAccuracy(NewWeaponType,1,
 {Corvette=0.90},
 {Corvette_hw1=0.90},
 {munition=0.04},
-{Frigate=0.90},
+{Frigate=0.95},
 {SmallCapitalShip=0.89},
 {BigCapitalShip=0.89},
 {SubSystem=1},
-{Resource=0.89},
-{ResourceLarge=0.6});
+{ResourceLarge=0.95});
 setAngles(NewWeaponType,10,-160,20,-10,60);
 setMiscValues(NewWeaponType,0.25,0);
 addAnimTurretSound(NewWeaponType,"Data:Sound/SFX/ETG/SPECIAL/SPECIAL_ABILITIES_TURRET_ON");
 setMissProperties(NewWeaponType, 0.02, 0.04, 0.50, 0.60, 0.70, 0.70);
 setLifetimeMult(NewWeaponType, 1.75);
-setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0);
+setSpeedvsAccuracyAgainst(NewWeaponType, 1, 50.0, 1.5, 200, 1.1, 300, 1.0, 350, 0.6);
 setBallistics(NewWeaponType,0,0.0);
 setFireMultFactor(NewWeaponType, 1.0);


### PR DESCRIPTION
Test data: [assault_projectile_speed.zip](https://github.com/HW-PlayersPatch/Development/files/4581154/assault_projectile_speed.zip)

These % increases make it sound like these got buffed massively, however with such tiny numbers this really isn't true.

After these buffs, they're still worse than torps. This might just mean torps do their anti-vette job waaaay too well, not sure.

**Assault Frigates:**
> These changes bring assaults closer to torps in terms of their ability to kill corvettes. When in gravwells, fighters are now also quite vulnerable.
  - **Weapon changes:**
    - **Kinetic guns:**
      - **Projectile speed:** `1800 => 2200` (+
      - **Penetration values:**
        - **vs all fighters:** `0.1 => 0.35` (+250%)
        - **vs hw2 corvettes:** `0.16 => 0.2` (+25%)
        - **vs hw1 corvettes:** `0.16 => 0.3` (+87%)
      - **Accuracy values:**
        - **vs units traveling at least 350m/s:** `1.0 => 0.6` (-40%)
        - **vs all frigates:** `0.9 => 0.95` (+5.6%)
        - **vs large utility:** `0.6 => 0.95` (+58%)
    - **Plasma bombs:**
      - **Penetration values:**
        - **vs all fighters:** `0.13 => 1` (+669%)
        - **vs hw2 corvettes:** `0.6 =>  0.7` (+16%)
     - **Accuracy values:**
        - **vs all fighters:** `0.03 => 0.1` (+233%)
        - **vs large utility:** `0.6 => 0.93` (+55%)