### PR TITLE
hw1 ms hp: 420k => 600k

### DIFF
--- a/2.3/ship/kus_mothership/kus_mothership.ship
+++ b/2.3/ship/kus_mothership/kus_mothership.ship
@@ -1,7 +1,7 @@
 NewShipType = StartShipConfig()
 NewShipType.displayedName="$10042"
 NewShipType.sobDescription="$10043"
-NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 420000)
+NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 600000)
 NewShipType.regentime=1400
 NewShipType.minRegenTime=1400
 NewShipType.sideArmourDamage=1.0

--- a/2.3/ship/tai_mothership/tai_mothership.ship
+++ b/2.3/ship/tai_mothership/tai_mothership.ship
@@ -1,7 +1,7 @@
 NewShipType = StartShipConfig()
 NewShipType.displayedName="$1627"
 NewShipType.sobDescription="$10043"
-NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 420000)
+NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 600000)
 NewShipType.regentime=1400
 NewShipType.minRegenTime=1400
 NewShipType.sideArmourDamage=1.0


### PR DESCRIPTION
Campaign HP is locked by the props already.

**Mothership:**
> Due to the critical importance of the mothership for hw1 players, knocking one of these down should be a major effort on the opponents end. This value is slighly lower than the combined health of an upgraded hw2 mothership plus a shipyard.
- **Health:** `420000 => 600000` (+42.8%)