### PR TITLE
Mdd vs hw2

### DIFF
--- a/2.3/weapon/kus_destroyerlauncher/kus_destroyerlauncher.wepn
+++ b/2.3/weapon/kus_destroyerlauncher/kus_destroyerlauncher.wepn
@@ -1,9 +1,9 @@
 StartWeaponConfig(NewWeaponType,"Fixed","Missile","Kus_Missile","Normal",350,4000,0,0,0,0,1,1,1,2.75,0,0,1,0,0,0,0.1,"Normal",1,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",130,130,"");
 setPenetration(NewWeaponType,15,0.5,
-{Unarmoured=0.24*2.4},
-{Unarmoured_hw1=0.24*2.4},
-{LightArmour=1.0 * 0.8},
+{Unarmoured=0.75},
+{Unarmoured_hw1=0.576},
+{LightArmour=1.5},
 {LightArmour_hw1=1.5 * 0.8},
 {MediumArmour=0.98},
 {HeavyArmour=1.25},

--- a/2.3/weapon/kus_destroyerlaunchervolley/kus_destroyerlaunchervolley.wepn
+++ b/2.3/weapon/kus_destroyerlaunchervolley/kus_destroyerlaunchervolley.wepn
@@ -1,9 +1,9 @@
 StartWeaponConfig(NewWeaponType,"Fixed","Missile","Kus_MissileVolley","Special Attack",675,4000,0,0,0,0,1,1,1,70,0,0,1,0,0,0,0.1,"Normal",1,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",260,260,"");
 setPenetration(NewWeaponType,25,0.5,
-{Unarmoured=0.24*3},
-{Unarmoured_hw1=0.24*3},
-{LightArmour=0.82},
+{Unarmoured=0.72},
+{Unarmoured_hw1=0.72},
+{LightArmour=1.5},
 {LightArmour_hw1=1.5},
 {MediumArmour=2.0},
 {HeavyArmour=2.5},

--- a/2.3/weapon/tai_destroyerlauncher/tai_destroyerlauncher.wepn
+++ b/2.3/weapon/tai_destroyerlauncher/tai_destroyerlauncher.wepn
@@ -1,9 +1,9 @@
 StartWeaponConfig(NewWeaponType,"Fixed","Missile","Tai_Missile","Normal",350,4000,0,0,0,0,1,1,1,2.75,0,0,1,0,0,0,0.1,"Normal",1,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",130,130,"");
 setPenetration(NewWeaponType,15,0.5,
-{Unarmoured=0.24*2.4},
+{Unarmoured=0.75},
 {Unarmoured_hw1=0.24*2.4},
-{LightArmour=1.0 * 0.8},
+{LightArmour=1.5},
 {LightArmour_hw1=1.5 * 0.8},
 {MediumArmour=0.98},
 {HeavyArmour=1.25},

--- a/2.3/weapon/tai_destroyerlaunchervolley/tai_destroyerlaunchervolley.wepn
+++ b/2.3/weapon/tai_destroyerlaunchervolley/tai_destroyerlaunchervolley.wepn
@@ -1,9 +1,9 @@
 StartWeaponConfig(NewWeaponType,"Fixed","Missile","Tai_MissileVolley","Special Attack",675,4000,0,0,0,0,1,1,1,70,0,0,1,0,0,0,0.1,"Normal",1,0,0);
 AddWeaponResult(NewWeaponType,"Hit","DamageHealth","Target",260,260,"");
 setPenetration(NewWeaponType,25,0.5,
-{Unarmoured=0.24*3},
-{Unarmoured_hw1=0.24*3},
-{LightArmour=0.82},
+{Unarmoured=0.72},
+{Unarmoured_hw1=0.72},
+{LightArmour=1.5},
 {LightArmour_hw1=1.5},
 {MediumArmour=2.0},
 {HeavyArmour=2.5},


### PR DESCRIPTION
Closes #372 

## Missile Destroyers
> MDDs are currently woefully inadequate at finishing off hw2 vette and fighter squadrons before they fly away for repairs.
- **Weapons:**
  - **Regular missiles:**
    - **Damage multipliers:**
      - vs hw2 fighters: `0.576 => 0.75` (+30%)
      - vs hw2 vettes: `0.8 => 1.5` (+87.5%)
  - **Volley missiles:**
      - vs hw2 vettes: `0.82 => 1.5` (+82.9%)