### PR TITLE
c1m03 more realistic reference fleet to fix assault frigate count

### DIFF
--- a/2.3/leveldata/campaign/homeworldclassic/mission03/referencefleet.lua
+++ b/2.3/leveldata/campaign/homeworldclassic/mission03/referencefleet.lua
@@ -13,19 +13,19 @@ Fleet =
     },
     {
         Type = "Kus_ResourceCollector",
-        Number = 3,
-    },
-    {
-        Type = "Kus_SalvageCorvette",
         Number = 2,
-    },    
+    },
     {
         Type = "Kus_Interceptor",
         Number = 20,
     },
     {
-        Type = "Kus_AttackBomber",
-        Number = 12,
+        Type = "Kus_SalvageCorvette",
+        Number = 2,
+    },
+    {
+        Type = "Kus_RepairCorvette",
+        Number = 2,
     },
     {
         Type = "Kus_LightCorvette",

--- a/2.3/leveldata/campaign/homeworldclassic/mission03/referencefleet.lua
+++ b/2.3/leveldata/campaign/homeworldclassic/mission03/referencefleet.lua
@@ -13,28 +13,32 @@ Fleet =
     },
     {
         Type = "Kus_ResourceCollector",
-        Number = 1,
+        Number = 3,
     },
     {
         Type = "Kus_SalvageCorvette",
-        Number = 3,
+        Number = 2,
     },    
     {
         Type = "Kus_Interceptor",
-        Number = 8,
+        Number = 20,
     },
     {
         Type = "Kus_AttackBomber",
-        Number = 8,
+        Number = 12,
     },
     {
         Type = "Kus_LightCorvette",
-        Number = 5,
+        Number = 10,
+    },
+    {
+        Type = "Kus_HeavyCorvette",
+        Number = 8,
     },
 }
 
 -- and we think they should have this much money:
-RUs = 400
+RUs = 800
 
 --Load expanded options
 dofilepath("data:scripts/playerspatch_util.lua")

--- a/2.3/leveldata/campaign/homeworldclassic/mission03/referencefleet.lua
+++ b/2.3/leveldata/campaign/homeworldclassic/mission03/referencefleet.lua
@@ -29,7 +29,7 @@ Fleet =
     },
     {
         Type = "Kus_LightCorvette",
-        Number = 10,
+        Number = 8,
     },
     {
         Type = "Kus_HeavyCorvette",
@@ -38,7 +38,7 @@ Fleet =
 }
 
 -- and we think they should have this much money:
-RUs = 800
+RUs = 1200
 
 --Load expanded options
 dofilepath("data:scripts/playerspatch_util.lua")

--- a/2.3/ship/kus_cryotray/kus_cryotray.ship
+++ b/2.3/ship/kus_cryotray/kus_cryotray.ship
@@ -1,7 +1,7 @@
 NewShipType = StartShipConfig()
 NewShipType.displayedName="$10062"
 NewShipType.sobDescription="$10063"
-NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 50000)
+NewShipType.maxhealth=getShipNum(NewShipType, "maxhealth", 55000)
 NewShipType.regentime=0
 NewShipType.minRegenTime=0
 NewShipType.sideArmourDamage = getShipNum(NewShipType, "sideArmourDamage", 1.0)


### PR DESCRIPTION
The reference fleet in this mission is puny, which causes a huge issue on this level much more than others. With a decent (not max, just above average) sized fleet you may be looking at upward of 12 assault frigates; just waaaay too many

With these changes,

- empty fleet produces 2 assaults
- reference fleet produces 3 assaults
- big fleet produces ~6 assaults
- huge fleet can produce up to 9 assaults

also cryo health +10%, they are not this fragile in classic

in classic, there are always 4 frigates, and there are not enough RU to have a big fleet anyway

part of the problem is the high amount of RU in the campaign, I think this is a tackleable issue for the first 5-6 missions